### PR TITLE
Add Quick Connect auth flow to login screens and ViewModel

### DIFF
--- a/app/src/main/java/com/rpeters/cinefintv/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/navigation/NavGraph.kt
@@ -77,8 +77,22 @@ fun CinefinTvNavGraph(
                 serverUrl = authUiState.connectedServerUrl ?: authUiState.serverUrlInput,
                 isAuthenticating = authUiState.isAuthenticating,
                 errorMessage = authUiState.loginError,
+                isQuickConnectEnabled = authUiState.isQuickConnectEnabled,
+                isQuickConnectLoading = authUiState.isQuickConnectLoading,
+                quickConnectCode = authUiState.quickConnectCode,
+                quickConnectPollStatus = authUiState.quickConnectPollStatus,
+                quickConnectError = authUiState.quickConnectError,
                 onLogin = { username, password ->
                     authViewModel.login(username, password)
+                },
+                onUseQuickConnect = {
+                    authViewModel.startQuickConnect()
+                },
+                onGenerateNewCode = {
+                    authViewModel.generateNewQuickConnectCode()
+                },
+                onLeaveScreen = {
+                    authViewModel.stopQuickConnect()
                 },
                 onBack = {
                     authViewModel.returnToServerEntry()

--- a/app/src/main/java/com/rpeters/cinefintv/ui/screens/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/screens/auth/AuthViewModel.kt
@@ -7,6 +7,8 @@ import com.rpeters.cinefintv.data.repository.JellyfinAuthRepository
 import com.rpeters.cinefintv.data.repository.common.ApiResult
 import com.rpeters.cinefintv.utils.ServerUrlValidator
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -24,6 +26,12 @@ data class AuthUiState(
     val loginSucceeded: Boolean = false,
     val isSessionChecked: Boolean = false,
     val isSessionActive: Boolean = false,
+    val isQuickConnectEnabled: Boolean = false,
+    val isQuickConnectLoading: Boolean = false,
+    val quickConnectCode: String? = null,
+    val quickConnectSecret: String? = null,
+    val quickConnectPollStatus: String? = null,
+    val quickConnectError: String? = null,
 )
 
 @HiltViewModel
@@ -31,6 +39,8 @@ class AuthViewModel @Inject constructor(
     private val authRepository: JellyfinAuthRepository,
     private val secureCredentialManager: SecureCredentialManager,
 ) : ViewModel() {
+    private var quickConnectPollJob: Job? = null
+
     private val _uiState = MutableStateFlow(AuthUiState())
     val uiState: StateFlow<AuthUiState> = _uiState.asStateFlow()
 
@@ -60,6 +70,7 @@ class AuthViewModel @Inject constructor(
     }
 
     fun testServerConnection() {
+        stopQuickConnect()
         val normalizedUrl = ServerUrlValidator.validateAndNormalizeUrl(_uiState.value.serverUrlInput)
         if (normalizedUrl == null) {
             _uiState.update {
@@ -91,6 +102,7 @@ class AuthViewModel @Inject constructor(
                             connectionError = null,
                         )
                     }
+                    checkQuickConnectAvailability(normalizedUrl)
                 }
                 is ApiResult.Error -> {
                     _uiState.update {
@@ -107,6 +119,7 @@ class AuthViewModel @Inject constructor(
     }
 
     fun login(username: String, password: String) {
+        stopQuickConnect()
         val serverUrl = _uiState.value.connectedServerUrl
             ?: ServerUrlValidator.validateAndNormalizeUrl(_uiState.value.serverUrlInput)
 
@@ -134,6 +147,7 @@ class AuthViewModel @Inject constructor(
             when (val result = authRepository.authenticateUser(serverUrl, username.trim(), password)) {
                 is ApiResult.Success -> {
                     secureCredentialManager.savePassword(serverUrl, username.trim(), password)
+                    stopQuickConnect()
                     _uiState.update {
                         it.copy(
                             isAuthenticating = false,
@@ -156,6 +170,200 @@ class AuthViewModel @Inject constructor(
         }
     }
 
+    fun startQuickConnect() {
+        val serverUrl = _uiState.value.connectedServerUrl
+            ?: ServerUrlValidator.validateAndNormalizeUrl(_uiState.value.serverUrlInput)
+
+        if (serverUrl == null) {
+            _uiState.update { it.copy(quickConnectError = "Connect to a valid server first.") }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    isQuickConnectLoading = true,
+                    quickConnectError = null,
+                    quickConnectCode = null,
+                    quickConnectSecret = null,
+                    quickConnectPollStatus = "Generating code...",
+                )
+            }
+
+            when (val result = authRepository.initiateQuickConnect(serverUrl)) {
+                is ApiResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isQuickConnectLoading = false,
+                            quickConnectCode = result.data.code,
+                            quickConnectSecret = result.data.secret,
+                            quickConnectPollStatus = "Waiting for approval...",
+                            quickConnectError = null,
+                            serverUrlInput = serverUrl,
+                            connectedServerUrl = serverUrl,
+                        )
+                    }
+                    beginQuickConnectPolling(serverUrl, result.data.secret)
+                }
+
+                is ApiResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            isQuickConnectLoading = false,
+                            quickConnectPollStatus = null,
+                            quickConnectError = result.message,
+                        )
+                    }
+                }
+
+                is ApiResult.Loading -> Unit
+            }
+        }
+    }
+
+    fun generateNewQuickConnectCode() {
+        stopQuickConnect()
+        startQuickConnect()
+    }
+
+    fun stopQuickConnect() {
+        quickConnectPollJob?.cancel()
+        quickConnectPollJob = null
+        _uiState.update {
+            it.copy(
+                isQuickConnectLoading = false,
+                quickConnectCode = null,
+                quickConnectSecret = null,
+                quickConnectPollStatus = null,
+                quickConnectError = null,
+            )
+        }
+    }
+
+    private fun checkQuickConnectAvailability(serverUrl: String) {
+        viewModelScope.launch {
+            when (val result = authRepository.isQuickConnectEnabled(serverUrl)) {
+                is ApiResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isQuickConnectEnabled = result.data,
+                            quickConnectError = if (result.data) it.quickConnectError else null,
+                        )
+                    }
+                }
+
+                is ApiResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            isQuickConnectEnabled = false,
+                            quickConnectError = result.message,
+                        )
+                    }
+                }
+
+                is ApiResult.Loading -> Unit
+            }
+        }
+    }
+
+    private fun beginQuickConnectPolling(serverUrl: String, secret: String) {
+        quickConnectPollJob?.cancel()
+        quickConnectPollJob = viewModelScope.launch {
+            while (true) {
+                when (val stateResult = authRepository.getQuickConnectState(serverUrl, secret)) {
+                    is ApiResult.Success -> {
+                        when {
+                            stateResult.data.isPending -> {
+                                _uiState.update {
+                                    it.copy(
+                                        quickConnectPollStatus = "Waiting for approval...",
+                                        quickConnectError = null,
+                                    )
+                                }
+                            }
+
+                            stateResult.data.isApproved -> {
+                                _uiState.update {
+                                    it.copy(quickConnectPollStatus = "Approving sign-in...")
+                                }
+                                authenticateWithQuickConnect(serverUrl, secret)
+                                return@launch
+                            }
+
+                            stateResult.data.isDenied -> {
+                                _uiState.update {
+                                    it.copy(
+                                        quickConnectPollStatus = null,
+                                        quickConnectError = "Quick Connect request denied. Generate a new code and try again.",
+                                    )
+                                }
+                                return@launch
+                            }
+
+                            stateResult.data.isExpired -> {
+                                _uiState.update {
+                                    it.copy(
+                                        quickConnectPollStatus = null,
+                                        quickConnectError = "Quick Connect code expired. Generate a new code to continue.",
+                                    )
+                                }
+                                return@launch
+                            }
+                        }
+                    }
+
+                    is ApiResult.Error -> {
+                        _uiState.update {
+                            it.copy(
+                                quickConnectPollStatus = null,
+                                quickConnectError = stateResult.message,
+                            )
+                        }
+                        return@launch
+                    }
+
+                    is ApiResult.Loading -> Unit
+                }
+
+                delay(3_000)
+            }
+        }
+    }
+
+    private fun authenticateWithQuickConnect(serverUrl: String, secret: String) {
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    isAuthenticating = true,
+                    quickConnectError = null,
+                )
+            }
+            when (val result = authRepository.authenticateWithQuickConnect(serverUrl, secret)) {
+                is ApiResult.Success -> {
+                    stopQuickConnect()
+                    _uiState.update {
+                        it.copy(
+                            isAuthenticating = false,
+                            loginSucceeded = true,
+                        )
+                    }
+                }
+
+                is ApiResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            isAuthenticating = false,
+                            quickConnectPollStatus = null,
+                            quickConnectError = result.message,
+                        )
+                    }
+                }
+
+                is ApiResult.Loading -> Unit
+            }
+        }
+    }
+
     fun resetLoginSuccess() {
         _uiState.update { it.copy(loginSucceeded = false) }
     }
@@ -165,12 +373,19 @@ class AuthViewModel @Inject constructor(
     }
 
     fun returnToServerEntry() {
+        stopQuickConnect()
         _uiState.update {
             it.copy(
                 connectedServerUrl = null,
                 loginError = null,
                 isAuthenticating = false,
+                isQuickConnectEnabled = false,
             )
         }
+    }
+
+    override fun onCleared() {
+        stopQuickConnect()
+        super.onCleared()
     }
 }

--- a/app/src/main/java/com/rpeters/cinefintv/ui/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/screens/auth/LoginScreen.kt
@@ -28,7 +28,15 @@ fun LoginScreen(
     serverUrl: String,
     isAuthenticating: Boolean,
     errorMessage: String?,
+    isQuickConnectEnabled: Boolean,
+    isQuickConnectLoading: Boolean,
+    quickConnectCode: String?,
+    quickConnectPollStatus: String?,
+    quickConnectError: String?,
     onLogin: (username: String, password: String) -> Unit,
+    onUseQuickConnect: () -> Unit,
+    onGenerateNewCode: () -> Unit,
+    onLeaveScreen: () -> Unit,
     onBack: () -> Unit,
 ) {
     var username by rememberSaveable { mutableStateOf("") }
@@ -89,6 +97,47 @@ fun LoginScreen(
             OutlinedButton(onClick = onBack) {
                 Text("Back")
             }
+        }
+
+        if (isQuickConnectEnabled) {
+            Button(
+                onClick = onUseQuickConnect,
+                enabled = !isQuickConnectLoading && !isAuthenticating,
+            ) {
+                Text(if (isQuickConnectLoading) "Generating Code..." else "Use Quick Connect")
+            }
+        }
+
+        if (quickConnectCode != null) {
+            Text(
+                text = "Quick Connect code: $quickConnectCode",
+                style = MaterialTheme.typography.titleLarge,
+            )
+        }
+
+        if (quickConnectPollStatus != null) {
+            Text(
+                text = quickConnectPollStatus,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (quickConnectError != null) {
+            Text(
+                text = quickConnectError,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            OutlinedButton(onClick = onGenerateNewCode) {
+                Text("Generate new code")
+            }
+        }
+    }
+
+    androidx.compose.runtime.DisposableEffect(Unit) {
+        onDispose {
+            onLeaveScreen()
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a Quick Connect sign-in option that leverages existing Jellyfin Quick Connect endpoints and offers a code-based sign-in path alongside username/password login.

### Description
- Extended `AuthUiState` with Quick Connect fields: `isQuickConnectEnabled`, `isQuickConnectLoading`, `quickConnectCode`, `quickConnectSecret`, `quickConnectPollStatus`, and `quickConnectError`.
- Added ViewModel intents in `AuthViewModel`: `startQuickConnect`, `generateNewQuickConnectCode`, `stopQuickConnect`, and internal `beginQuickConnectPolling` and `authenticateWithQuickConnect`, wired to repository methods `isQuickConnectEnabled`, `initiateQuickConnect`, `getQuickConnectState`, and `authenticateWithQuickConnect`.
- Implemented polling with a cancellable `Job` and `delay` that handles `Pending`/`Approved`/`Denied`/`Expired` states, cancels on leaving the screen or on success/failure, and reuses the existing `loginSucceeded` path to preserve navigation behavior.
- Updated UI: added a “Use Quick Connect” button, code display, poll status text, error display and a `Generate new code` retry action in `LoginScreen`, and wired callbacks through `NavGraph` to the new ViewModel intents.

### Testing
- Attempted to compile Kotlin with `bash ./gradlew :app:compileDebugKotlin` but the Gradle wrapper download failed in this environment due to a network proxy returning `HTTP 403`, so full local build verification could not run.
- Verified code changes by static inspection and by running quick checks of modified source files; no automated unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a549c90d5c832789f6eccfd4c6dec6)