### PR TITLE
Use stream artwork helpers for search result cards

### DIFF
--- a/app/src/main/java/com/rpeters/cinefintv/data/repository/JellyfinStreamRepository.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/data/repository/JellyfinStreamRepository.kt
@@ -444,6 +444,31 @@ class JellyfinStreamRepository @Inject constructor(
     }
 
     /**
+     * Get image URL for search cards with a fallback order of Primary -> Backdrop -> Thumb.
+     */
+    fun getSearchCardImageUrl(item: BaseItemDto): String? {
+        val itemId = item.id?.toString() ?: return null
+
+        if (item.type == BaseItemKind.EPISODE && item.seriesId != null) {
+            return getImageUrl(item.seriesId.toString(), "Primary")
+        }
+
+        item.imageTags?.get(ImageType.PRIMARY)?.let { primaryTag ->
+            return getImageUrl(itemId, "Primary", primaryTag)
+        }
+
+        item.backdropImageTags?.firstOrNull()?.let { backdropTag ->
+            return getImageUrl(itemId, "Backdrop", backdropTag)
+        }
+
+        item.imageTags?.get(ImageType.THUMB)?.let { thumbTag ->
+            return getImageUrl(itemId, "Thumb", thumbTag)
+        }
+
+        return null
+    }
+
+    /**
      * Get backdrop URL for an item
      */
     fun getBackdropUrl(item: BaseItemDto): String? {

--- a/app/src/main/java/com/rpeters/cinefintv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/screens/search/SearchViewModel.kt
@@ -2,7 +2,7 @@ package com.rpeters.cinefintv.ui.screens.search
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.rpeters.cinefintv.data.repository.JellyfinSearchRepository
+import com.rpeters.cinefintv.data.repository.JellyfinRepositoryCoordinator
 import com.rpeters.cinefintv.data.repository.common.ApiResult
 import com.rpeters.cinefintv.ui.screens.home.HomeCardModel
 import com.rpeters.cinefintv.utils.getDisplayTitle
@@ -29,7 +29,7 @@ data class SearchUiState(
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
-    private val searchRepository: JellyfinSearchRepository,
+    private val repositories: JellyfinRepositoryCoordinator,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(SearchUiState())
     val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
@@ -73,7 +73,7 @@ class SearchViewModel @Inject constructor(
 
         _uiState.update { it.copy(isLoading = true, errorMessage = null) }
 
-        when (val result = searchRepository.searchItems(query, limit = 60)) {
+        when (val result = repositories.search.searchItems(query, limit = 60)) {
             is ApiResult.Success -> {
                 _uiState.update {
                     it.copy(
@@ -105,7 +105,7 @@ class SearchViewModel @Inject constructor(
             id = id,
             title = item.getDisplayTitle(),
             subtitle = subtitle,
-            imageUrl = null,
+            imageUrl = repositories.stream.getSearchCardImageUrl(item),
         )
     }
 }


### PR DESCRIPTION
### Motivation
- Search results currently had no image and should display artwork using the same repository helpers used elsewhere. 
- Provide a consistent, media-aware fallback order for search-card artwork (Primary -> Backdrop -> Thumb) while preserving episodes’ series-poster behavior. 

### Description
- Updated `SearchViewModel` to accept `JellyfinRepositoryCoordinator` and call `repositories.search.searchItems(...)` instead of the previous search repository reference. 
- `toCardModel()` in `SearchViewModel` now sets `imageUrl = repositories.stream.getSearchCardImageUrl(item)` instead of `null`. 
- Added `JellyfinStreamRepository.getSearchCardImageUrl(item: BaseItemDto)` which resolves artwork with the fallback order `Primary -> Backdrop -> Thumb` and uses the series primary image for episodes when available. 
- Verified `SearchScreen.kt` still passes `HomeCardModel.imageUrl` directly into `TvMediaCard` unchanged. 

### Testing
- Attempted to compile with `./gradlew :app:compileDebugKotlin`, but the Gradle wrapper download was blocked by the environment proxy resulting in a failed build (HTTP 403), so no local compile succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a549cbc5e0832790a5def5c1147999)