### PR TITLE
Add playback resume and autosave with optional Jellyfin sync

### DIFF
--- a/app/src/main/java/com/rpeters/cinefintv/ui/player/PlayerScreen.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/player/PlayerScreen.kt
@@ -30,7 +30,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.media3.common.Player
 import androidx.media3.common.MediaItem
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
@@ -96,6 +100,8 @@ fun PlayerScreen(
 
         else -> {
             val player = rememberExoPlayer(uiState.streamUrl.orEmpty(), viewModel.okHttpClient)
+            val lifecycleOwner = LocalLifecycleOwner.current
+            var hasAppliedInitialSeek by remember(uiState.itemId) { mutableStateOf(false) }
 
             // Playback state — polled every 500ms
             var isPlaying by remember { mutableStateOf(true) }
@@ -107,6 +113,61 @@ fun PlayerScreen(
                     position = player.currentPosition.coerceAtLeast(0L)
                     duration = player.duration.coerceAtLeast(0L)
                     delay(500L)
+                }
+            }
+
+            LaunchedEffect(player, isPlaying) {
+                while (true) {
+                    if (isPlaying) {
+                        viewModel.savePlaybackPosition(
+                            positionMs = player.currentPosition,
+                            durationMs = player.duration.coerceAtLeast(0L),
+                            isPaused = false,
+                        )
+                    }
+                    delay(POSITION_SAVE_INTERVAL_MS)
+                }
+            }
+
+            DisposableEffect(player, uiState.savedPlaybackPositionMs) {
+                val listener = object : Player.Listener {
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        if (
+                            playbackState == Player.STATE_READY &&
+                            !hasAppliedInitialSeek &&
+                            uiState.savedPlaybackPositionMs > 0L
+                        ) {
+                            player.seekTo(uiState.savedPlaybackPositionMs)
+                            hasAppliedInitialSeek = true
+                        }
+                    }
+                }
+                player.addListener(listener)
+
+                onDispose {
+                    player.removeListener(listener)
+                    viewModel.savePlaybackPosition(
+                        positionMs = player.currentPosition,
+                        durationMs = player.duration.coerceAtLeast(0L),
+                        isPaused = !player.isPlaying,
+                    )
+                }
+            }
+
+            DisposableEffect(lifecycleOwner, player) {
+                val observer = LifecycleEventObserver { _, event ->
+                    if (event == Lifecycle.Event.ON_PAUSE || event == Lifecycle.Event.ON_STOP) {
+                        viewModel.savePlaybackPosition(
+                            positionMs = player.currentPosition,
+                            durationMs = player.duration.coerceAtLeast(0L),
+                            isPaused = true,
+                        )
+                    }
+                }
+
+                lifecycleOwner.lifecycle.addObserver(observer)
+                onDispose {
+                    lifecycleOwner.lifecycle.removeObserver(observer)
                 }
             }
 
@@ -234,6 +295,8 @@ fun PlayerScreen(
         }
     }
 }
+
+private const val POSITION_SAVE_INTERVAL_MS = 10_000L
 
 @Composable
 private fun rememberExoPlayer(streamUrl: String, okHttpClient: OkHttpClient): ExoPlayer {

--- a/app/src/main/java/com/rpeters/cinefintv/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/player/PlayerViewModel.kt
@@ -1,23 +1,28 @@
 package com.rpeters.cinefintv.ui.player
 
+import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.rpeters.cinefintv.data.PlaybackPositionStore
 import com.rpeters.cinefintv.data.repository.JellyfinRepositoryCoordinator
 import com.rpeters.cinefintv.data.repository.common.ApiResult
 import com.rpeters.cinefintv.utils.getDisplayTitle
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
+import java.util.UUID
 import javax.inject.Inject
 
 data class PlayerUiState(
     val itemId: String = "",
     val title: String = "Player",
     val streamUrl: String? = null,
+    val savedPlaybackPositionMs: Long = 0L,
     val isLoading: Boolean = true,
     val errorMessage: String? = null,
 )
@@ -26,8 +31,10 @@ data class PlayerUiState(
 class PlayerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val repositories: JellyfinRepositoryCoordinator,
+    @ApplicationContext private val appContext: Context,
     val okHttpClient: OkHttpClient,
 ) : ViewModel() {
+    private val playbackSessionId: String = UUID.randomUUID().toString()
     private val itemId: String = savedStateHandle.get<String>("itemId").orEmpty()
     private val _uiState = MutableStateFlow(
         PlayerUiState(
@@ -51,6 +58,7 @@ class PlayerViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
+            val savedPlaybackPositionMs = PlaybackPositionStore.getPlaybackPosition(appContext, itemId)
             val streamUrl = repositories.stream.getStreamUrl(itemId)
             if (streamUrl == null) {
                 _uiState.value = PlayerUiState(
@@ -70,8 +78,47 @@ class PlayerViewModel @Inject constructor(
                 itemId = itemId,
                 title = title,
                 streamUrl = streamUrl,
+                savedPlaybackPositionMs = savedPlaybackPositionMs,
                 isLoading = false,
             )
         }
+    }
+
+    fun savePlaybackPosition(
+        positionMs: Long,
+        durationMs: Long,
+        isPaused: Boolean = true,
+        shouldSyncToServer: Boolean = true,
+    ) {
+        if (itemId.isBlank()) return
+
+        viewModelScope.launch {
+            val isCompleted = durationMs > 0L && positionMs >= (durationMs * COMPLETION_THRESHOLD_PERCENT)
+            val persistedPosition = if (isCompleted) 0L else positionMs.coerceAtLeast(0L)
+            PlaybackPositionStore.savePlaybackPosition(appContext, itemId, persistedPosition)
+
+            if (shouldSyncToServer) {
+                val positionTicks = if (persistedPosition <= 0L) null else persistedPosition * TICKS_PER_MILLISECOND
+                if (isCompleted) {
+                    repositories.user.reportPlaybackStopped(
+                        itemId = itemId,
+                        sessionId = playbackSessionId,
+                        positionTicks = positionTicks,
+                    )
+                } else {
+                    repositories.user.reportPlaybackProgress(
+                        itemId = itemId,
+                        sessionId = playbackSessionId,
+                        positionTicks = positionTicks,
+                        isPaused = isPaused,
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val COMPLETION_THRESHOLD_PERCENT = 0.95
+        private const val TICKS_PER_MILLISECOND = 10_000L
     }
 }


### PR DESCRIPTION
### Motivation
- Persist and restore playback progress so users can resume where they left off and the app can optionally report progress to Jellyfin.
- Avoid retaining resume points for completed items by clearing saved position when an item is effectively finished.

### Description
- Load saved resume position in `PlayerViewModel.load()` via `PlaybackPositionStore.getPlaybackPosition(...)` and expose it on `PlayerUiState` as `savedPlaybackPositionMs`.
- Add `PlayerViewModel.savePlaybackPosition(...)` to centralize persistence and (optionally) server sync, generate a `playbackSessionId`, convert ms⇄ticks, and clear the saved point when >=95% watched.
- Update `PlayerScreen` to seek the `ExoPlayer` to `savedPlaybackPositionMs` once the player reaches `STATE_READY` and ensure the initial seek is applied only once.
- Add periodic autosave while playing (`POSITION_SAVE_INTERVAL_MS = 10_000L`), lifecycle-triggered saves on `ON_PAUSE`/`ON_STOP`, and a final save on dispose; wire calls to the new `savePlaybackPosition` function.

### Testing
- Attempted Kotlin compilation with `./gradlew :app:compileDebugKotlin`, which failed in this environment because the Gradle wrapper download was blocked by a network proxy (`HTTP 403 Forbidden`).
- No other automated tests were run in this environment due to the network restriction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a549cf11e483278bb4b201c2f63fc4)