### PR TITLE
Add auto-play next episode, track selection, and playback preferences to player

### DIFF
--- a/app/src/main/java/com/rpeters/cinefintv/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/navigation/NavGraph.kt
@@ -172,6 +172,11 @@ fun CinefinTvNavGraph(
                 onBack = {
                     navController.popBackStack()
                 },
+                onOpenItem = { nextItemId ->
+                    navController.navigate(NavRoutes.player(nextItemId)) {
+                        popUpTo(NavRoutes.PLAYER) { inclusive = true }
+                    }
+                },
             )
         }
     }

--- a/app/src/main/java/com/rpeters/cinefintv/ui/player/PlayerScreen.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/player/PlayerScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,10 +35,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.media3.common.Player
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
-import androidx.media3.common.Tracks
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
@@ -49,12 +49,14 @@ import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Switch
 import androidx.tv.material3.Text
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 fun PlayerScreen(
     onBack: () -> Unit,
+    onOpenItem: (String) -> Unit = {},
     viewModel: PlayerViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -104,7 +106,11 @@ fun PlayerScreen(
         else -> {
             val player = rememberExoPlayer(uiState.streamUrl.orEmpty(), viewModel.okHttpClient)
             val lifecycleOwner = LocalLifecycleOwner.current
+            val coroutineScope = rememberCoroutineScope()
             var hasAppliedInitialSeek by remember(uiState.itemId) { mutableStateOf(false) }
+            var isTrackPanelVisible by remember { mutableStateOf(false) }
+            var audioTracks by remember { mutableStateOf<List<TrackOption>>(emptyList()) }
+            var subtitleTracks by remember { mutableStateOf<List<TrackOption>>(emptyList()) }
 
             // Playback state — polled every 500ms
             var isPlaying by remember { mutableStateOf(true) }
@@ -143,6 +149,53 @@ fun PlayerScreen(
                             player.seekTo(uiState.savedPlaybackPositionMs)
                             hasAppliedInitialSeek = true
                         }
+
+                        if (
+                            playbackState == Player.STATE_ENDED &&
+                            uiState.isEpisodicContent &&
+                            uiState.autoPlayNextEpisode
+                        ) {
+                            viewModel.savePlaybackPosition(
+                                positionMs = player.currentPosition,
+                                durationMs = player.duration.coerceAtLeast(0L),
+                                isPaused = true,
+                            )
+
+                            player.pause()
+                            player.seekTo(0L)
+
+                            coroutineScope.launch {
+                                viewModel.getNextEpisodeId()?.let { onOpenItem(it) }
+                            }
+                        }
+                    }
+
+                    override fun onTracksChanged(tracks: androidx.media3.common.Tracks) {
+                        audioTracks = tracks.groups
+                            .filter { it.type == C.TRACK_TYPE_AUDIO }
+                            .flatMap { group ->
+                                (0 until group.length).map { index ->
+                                    val format = group.getTrackFormat(index)
+                                    TrackOption(
+                                        id = "audio-${group.mediaTrackGroup.id ?: index}-$index",
+                                        label = format.label ?: format.language ?: "Audio ${index + 1}",
+                                        language = format.language,
+                                    )
+                                }
+                            }
+
+                        subtitleTracks = tracks.groups
+                            .filter { it.type == C.TRACK_TYPE_TEXT }
+                            .flatMap { group ->
+                                (0 until group.length).map { index ->
+                                    val format = group.getTrackFormat(index)
+                                    TrackOption(
+                                        id = "sub-${group.mediaTrackGroup.id ?: index}-$index",
+                                        label = format.label ?: format.language ?: "Subtitle ${index + 1}",
+                                        language = format.language,
+                                    )
+                                }
+                            }
                     }
                 }
                 player.addListener(listener)

--- a/app/src/main/java/com/rpeters/cinefintv/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/player/PlayerViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rpeters.cinefintv.data.PlaybackPositionStore
+import com.rpeters.cinefintv.data.preferences.PlaybackPreferencesRepository
 import com.rpeters.cinefintv.data.repository.JellyfinRepositoryCoordinator
 import com.rpeters.cinefintv.data.repository.common.ApiResult
 import com.rpeters.cinefintv.utils.getDisplayTitle
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
+import org.jellyfin.sdk.model.api.BaseItemKind
 import java.util.UUID
 import javax.inject.Inject
 
@@ -30,6 +32,10 @@ data class PlayerUiState(
     val title: String = "Player",
     val streamUrl: String? = null,
     val savedPlaybackPositionMs: Long = 0L,
+    val isEpisodicContent: Boolean = false,
+    val autoPlayNextEpisode: Boolean = true,
+    val selectedAudioTrack: TrackOption? = null,
+    val selectedSubtitleTrack: TrackOption? = null,
     val isLoading: Boolean = true,
     val errorMessage: String? = null,
 )
@@ -38,6 +44,7 @@ data class PlayerUiState(
 class PlayerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val repositories: JellyfinRepositoryCoordinator,
+    private val playbackPreferencesRepository: PlaybackPreferencesRepository,
     @ApplicationContext private val appContext: Context,
     val okHttpClient: OkHttpClient,
 ) : ViewModel() {
@@ -96,8 +103,35 @@ class PlayerViewModel @Inject constructor(
                 title = title,
                 streamUrl = streamUrl,
                 savedPlaybackPositionMs = savedPlaybackPositionMs,
+                isEpisodicContent = isEpisodicContent,
+                autoPlayNextEpisode = _uiState.value.autoPlayNextEpisode,
+                selectedAudioTrack = _uiState.value.selectedAudioTrack,
+                selectedSubtitleTrack = _uiState.value.selectedSubtitleTrack,
                 isLoading = false,
             )
+        }
+    }
+
+    fun setAutoPlayNextEpisode(enabled: Boolean) {
+        viewModelScope.launch {
+            playbackPreferencesRepository.setAutoPlayNextEpisode(enabled)
+            _uiState.value = _uiState.value.copy(autoPlayNextEpisode = enabled)
+        }
+    }
+
+    fun onAudioTrackSelected(track: TrackOption?) {
+        _uiState.value = _uiState.value.copy(selectedAudioTrack = track)
+    }
+
+    fun onSubtitleTrackSelected(track: TrackOption?) {
+        _uiState.value = _uiState.value.copy(selectedSubtitleTrack = track)
+    }
+
+    suspend fun getNextEpisodeId(): String? {
+        if (!uiState.value.isEpisodicContent || !uiState.value.autoPlayNextEpisode) return null
+        return when (val result = repositories.media.getNextEpisode(itemId)) {
+            is ApiResult.Success -> result.data?.id?.toString()
+            else -> null
         }
     }
 

--- a/app/src/test/java/com/rpeters/cinefintv/ui/player/PlayerViewModelTest.kt
+++ b/app/src/test/java/com/rpeters/cinefintv/ui/player/PlayerViewModelTest.kt
@@ -1,12 +1,20 @@
 package com.rpeters.cinefintv.ui.player
 
+import android.content.Context
 import androidx.lifecycle.SavedStateHandle
+import com.rpeters.cinefintv.data.PlaybackPositionStore
+import com.rpeters.cinefintv.data.preferences.PlaybackPreferences
+import com.rpeters.cinefintv.data.preferences.PlaybackPreferencesRepository
 import com.rpeters.cinefintv.data.repository.common.ApiResult
 import com.rpeters.cinefintv.testutil.FakePlayerRepositories
 import com.rpeters.cinefintv.testutil.MainDispatcherRule
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
@@ -21,11 +29,22 @@ class PlayerViewModelTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
+    private val appContext: Context = mockk(relaxed = true)
+    private val playbackPreferencesRepository: PlaybackPreferencesRepository = mockk {
+        every { preferences } returns flowOf(PlaybackPreferences.DEFAULT)
+    }
+
+    init {
+        mockkObject(PlaybackPositionStore)
+    }
+
     @Test
     fun load_whenItemIdMissing_setsFriendlyError() = runTest {
         val viewModel = PlayerViewModel(
             savedStateHandle = SavedStateHandle(mapOf("itemId" to "")),
             repositories = FakePlayerRepositories().coordinator,
+            playbackPreferencesRepository = playbackPreferencesRepository,
+            appContext = appContext,
             okHttpClient = OkHttpClient(),
         )
         advanceUntilIdle()
@@ -39,10 +58,13 @@ class PlayerViewModelTest {
     fun load_whenStreamUrlMissing_setsStreamError() = runTest {
         val fakeRepositories = FakePlayerRepositories()
         every { fakeRepositories.stream.getStreamUrl("item-1") } returns null
+        coEvery { PlaybackPositionStore.getPlaybackPosition(appContext, "item-1") } returns 0L
 
         val viewModel = PlayerViewModel(
             savedStateHandle = SavedStateHandle(mapOf("itemId" to "item-1")),
             repositories = fakeRepositories.coordinator,
+            playbackPreferencesRepository = playbackPreferencesRepository,
+            appContext = appContext,
             okHttpClient = OkHttpClient(),
         )
         advanceUntilIdle()
@@ -57,10 +79,13 @@ class PlayerViewModelTest {
         val fakeRepositories = FakePlayerRepositories()
         every { fakeRepositories.stream.getStreamUrl("item-1") } returns "https://stream/item-1"
         coEvery { fakeRepositories.media.getItemDetails("item-1") } returns ApiResult.Error("not found")
+        coEvery { PlaybackPositionStore.getPlaybackPosition(appContext, "item-1") } returns 0L
 
         val viewModel = PlayerViewModel(
             savedStateHandle = SavedStateHandle(mapOf("itemId" to "item-1")),
             repositories = fakeRepositories.coordinator,
+            playbackPreferencesRepository = playbackPreferencesRepository,
+            appContext = appContext,
             okHttpClient = OkHttpClient(),
         )
         advanceUntilIdle()
@@ -68,6 +93,11 @@ class PlayerViewModelTest {
         val state = viewModel.uiState.value
         assertEquals("Now Playing", state.title)
         assertEquals("https://stream/item-1", state.streamUrl)
+    }
+
+    @org.junit.After
+    fun tearDown() {
+        unmockkObject(PlaybackPositionStore)
     }
 
 }


### PR DESCRIPTION
### Motivation

- Support automatic continuation to the next episode for episodic content and expose audio/subtitle track options to the UI.
- Persist and honor user playback preferences such as `autoPlayNextEpisode`.
- Ensure navigation opens the next episode player instance and replaces the current player entry in the back stack.

### Description

- Updated the navigation graph to provide an `onOpenItem` path for the player that navigates to `NavRoutes.player(nextItemId)` and `popUpTo(NavRoutes.PLAYER) { inclusive = true }` to replace the current player screen.
- Extended `PlayerScreen` with an `onOpenItem` callback, a `CoroutineScope`, and a `Player.Listener` handler that detects `Player.STATE_ENDED` to save position, pause/seek the player, and request the next episode via `viewModel.getNextEpisodeId()` before invoking `onOpenItem`; also added handling for `onTracksChanged` to populate `audioTracks` and `subtitleTracks` as `TrackOption` entries.
- Added `TrackOption` model and expanded `PlayerUiState` with `isEpisodicContent`, `autoPlayNextEpisode`, `selectedAudioTrack`, and `selectedSubtitleTrack` fields, and wired a `PlaybackPreferencesRepository` into `PlayerViewModel` to collect preferences and provide `setAutoPlayNextEpisode`, `onAudioTrackSelected`, `onSubtitleTrackSelected`, and `getNextEpisodeId` helpers.
- Updated `load()` in `PlayerViewModel` to detect episodic content and carry prior selections and preference state into the UI state.
- Tests updated to mock `PlaybackPreferencesRepository` and `PlaybackPositionStore`, add an `appContext` mock, and clean up mocked objects in `tearDown()`.

### Testing

- Ran unit tests for the player view model (`PlayerViewModelTest`) with the mocked `PlaybackPreferencesRepository` and `PlaybackPositionStore` using `runTest`; they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5489a80408327a6e6b4fe009e3ed0)