### PR TITLE
Add Stuff (Home Videos) library and detail screens with navigation

### DIFF
--- a/app/src/main/java/com/rpeters/cinefintv/ui/CinefinTvApp.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/CinefinTvApp.kt
@@ -33,7 +33,7 @@ private val navTabItems = listOf(
     NavTabItem("TV Shows", NavRoutes.LIBRARY_TVSHOWS),
     NavTabItem("Movies", NavRoutes.LIBRARY_MOVIES),
     NavTabItem("Music", NavRoutes.LIBRARY_MUSIC),
-    NavTabItem("Stuff", NavRoutes.LIBRARY_STUFF),
+    NavTabItem("Stuff (Home Videos)", NavRoutes.LIBRARY_STUFF),
     NavTabItem("Settings", NavRoutes.SETTINGS),
 )
 

--- a/app/src/main/java/com/rpeters/cinefintv/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/navigation/NavGraph.kt
@@ -25,6 +25,8 @@ import com.rpeters.cinefintv.ui.screens.home.HomeScreen
 import com.rpeters.cinefintv.ui.screens.library.LibraryCategory
 import com.rpeters.cinefintv.ui.screens.library.LibraryScreen
 import com.rpeters.cinefintv.ui.screens.music.MusicScreen
+import com.rpeters.cinefintv.ui.screens.stuff.StuffDetailScreen
+import com.rpeters.cinefintv.ui.screens.stuff.StuffLibraryScreen
 import com.rpeters.cinefintv.ui.screens.search.SearchScreen
 import com.rpeters.cinefintv.ui.player.PlayerScreen
 
@@ -134,10 +136,9 @@ fun CinefinTvNavGraph(
             )
         }
         composable(NavRoutes.LIBRARY_STUFF) {
-            LibraryScreen(
-                category = LibraryCategory.STUFF,
+            StuffLibraryScreen(
                 onOpenItem = { itemId ->
-                    navController.navigate(NavRoutes.detail(itemId))
+                    navController.navigate(NavRoutes.stuffDetail(itemId))
                 },
             )
         }
@@ -164,6 +165,22 @@ fun CinefinTvNavGraph(
                 },
                 onNavigate = { route ->
                     navController.navigate(route)
+                },
+                onBack = {
+                    navController.popBackStack()
+                },
+            )
+        }
+        composable(
+            NavRoutes.STUFF_DETAIL,
+            arguments = listOf(navArgument("itemId") { type = NavType.StringType }),
+        ) {
+            StuffDetailScreen(
+                onPlay = { itemId ->
+                    navController.navigate(NavRoutes.player(itemId))
+                },
+                onOpenItem = { itemId ->
+                    navController.navigate(NavRoutes.stuffDetail(itemId))
                 },
                 onBack = {
                     navController.popBackStack()

--- a/app/src/main/java/com/rpeters/cinefintv/ui/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/navigation/NavRoutes.kt
@@ -9,10 +9,12 @@ object NavRoutes {
     const val LIBRARY_MUSIC = "library/music"
     const val SETTINGS = "settings"
     const val DETAIL = "detail/{itemId}"
+    const val STUFF_DETAIL = "stuff/detail/{itemId}"
     const val PLAYER = "player/{itemId}"
 
     fun detail(itemId: String) = "detail/$itemId"
     fun player(itemId: String) = "player/$itemId"
+    fun stuffDetail(itemId: String) = "stuff/detail/$itemId"
 }
 
 object AuthRoutes {

--- a/app/src/main/java/com/rpeters/cinefintv/ui/screens/stuff/StuffDetailScreen.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/screens/stuff/StuffDetailScreen.kt
@@ -1,0 +1,154 @@
+package com.rpeters.cinefintv.ui.screens.stuff
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.Button
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.OutlinedButton
+import androidx.tv.material3.Text
+import coil3.compose.AsyncImage
+import com.rpeters.cinefintv.ui.components.TvMediaCard
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun StuffDetailScreen(
+    onPlay: (String) -> Unit,
+    onOpenItem: (String) -> Unit,
+    onBack: () -> Unit,
+    viewModel: StuffDetailViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (val state = uiState) {
+        is StuffDetailUiState.Loading -> Text(
+            text = "Loading Stuff details...",
+            style = MaterialTheme.typography.headlineMedium,
+            modifier = Modifier.padding(48.dp),
+        )
+
+        is StuffDetailUiState.Error -> {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(48.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text("Stuff detail could not load", style = MaterialTheme.typography.headlineLarge)
+                Text(
+                    text = state.message,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Button(onClick = viewModel::load) { Text("Retry") }
+                    OutlinedButton(onClick = onBack) { Text("Back") }
+                }
+            }
+        }
+
+        is StuffDetailUiState.Content -> {
+            val item = state.item
+            Box(modifier = Modifier.fillMaxSize()) {
+                if (item.backdropUrl != null) {
+                    AsyncImage(
+                        model = item.backdropUrl,
+                        contentDescription = item.title,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            Brush.verticalGradient(
+                                colors = listOf(
+                                    Color.Transparent,
+                                    Color.Black.copy(alpha = 0.7f),
+                                    Color.Black,
+                                ),
+                            ),
+                        ),
+                )
+
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(horizontal = 48.dp),
+                ) {
+                    item { Spacer(Modifier.fillParentMaxHeight(0.35f)) }
+                    item {
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            item.metadataLine?.let {
+                                Text(
+                                    text = it,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            Text(item.title, style = MaterialTheme.typography.displaySmall)
+                            item.overview?.takeIf { it.isNotBlank() }?.let {
+                                Text(
+                                    text = it,
+                                    maxLines = 4,
+                                    overflow = TextOverflow.Ellipsis,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                                Button(onClick = { onPlay(item.id) }) { Text("Play") }
+                                OutlinedButton(onClick = onBack) { Text("Back") }
+                            }
+                        }
+                    }
+
+                    if (state.moreFromStuff.isNotEmpty()) {
+                        item { Spacer(Modifier.height(28.dp)) }
+                        item {
+                            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                                Text("More Stuff", style = MaterialTheme.typography.titleLarge)
+                                LazyRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                                    items(state.moreFromStuff, key = { it.id }) { related ->
+                                        TvMediaCard(
+                                            title = related.title,
+                                            subtitle = related.subtitle,
+                                            imageUrl = related.imageUrl,
+                                            onClick = { onOpenItem(related.id) },
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/rpeters/cinefintv/ui/screens/stuff/StuffDetailViewModel.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/screens/stuff/StuffDetailViewModel.kt
@@ -1,0 +1,104 @@
+package com.rpeters.cinefintv.ui.screens.stuff
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.rpeters.cinefintv.data.repository.JellyfinRepositoryCoordinator
+import com.rpeters.cinefintv.data.repository.common.ApiResult
+import com.rpeters.cinefintv.utils.getDisplayTitle
+import com.rpeters.cinefintv.utils.getFormattedDuration
+import com.rpeters.cinefintv.utils.getYear
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+sealed class StuffDetailUiState {
+    data object Loading : StuffDetailUiState()
+    data class Error(val message: String) : StuffDetailUiState()
+    data class Content(
+        val item: StuffDetailModel,
+        val moreFromStuff: List<StuffItemCardModel>,
+    ) : StuffDetailUiState()
+}
+
+data class StuffDetailModel(
+    val id: String,
+    val title: String,
+    val overview: String?,
+    val metadataLine: String?,
+    val imageUrl: String?,
+    val backdropUrl: String?,
+)
+
+@HiltViewModel
+class StuffDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val repositories: JellyfinRepositoryCoordinator,
+) : ViewModel() {
+    private val itemId = savedStateHandle.get<String>("itemId").orEmpty()
+
+    private val _uiState = MutableStateFlow<StuffDetailUiState>(StuffDetailUiState.Loading)
+    val uiState: StateFlow<StuffDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        if (itemId.isBlank()) {
+            _uiState.value = StuffDetailUiState.Error("No Stuff item ID was provided.")
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.value = StuffDetailUiState.Loading
+
+            val detailsResult = repositories.media.getItemDetails(itemId)
+            val libraryResult = repositories.media.getLibraryItems(collectionType = "homevideos", limit = 40)
+
+            if (detailsResult !is ApiResult.Success) {
+                val message = (detailsResult as? ApiResult.Error)?.message ?: "Unable to load Stuff details."
+                _uiState.value = StuffDetailUiState.Error(message)
+                return@launch
+            }
+
+            val item = detailsResult.data
+            val metadata = listOfNotNull(item.getYear()?.toString(), item.getFormattedDuration())
+                .joinToString(" • ")
+                .ifBlank { null }
+
+            val moreItems = if (libraryResult is ApiResult.Success) {
+                libraryResult.data
+                    .asSequence()
+                    .filter { it.id.toString() != itemId }
+                    .take(16)
+                    .map {
+                        StuffItemCardModel(
+                            id = it.id.toString(),
+                            title = it.getDisplayTitle(),
+                            subtitle = it.getYear()?.toString() ?: it.getFormattedDuration(),
+                            imageUrl = repositories.stream.getSeriesImageUrl(it),
+                        )
+                    }
+                    .toList()
+            } else {
+                emptyList()
+            }
+
+            _uiState.value = StuffDetailUiState.Content(
+                item = StuffDetailModel(
+                    id = itemId,
+                    title = item.getDisplayTitle(),
+                    overview = item.overview,
+                    metadataLine = metadata,
+                    imageUrl = repositories.stream.getSeriesImageUrl(item),
+                    backdropUrl = repositories.stream.getBackdropUrl(item),
+                ),
+                moreFromStuff = moreItems,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/rpeters/cinefintv/ui/screens/stuff/StuffLibraryScreen.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/screens/stuff/StuffLibraryScreen.kt
@@ -1,0 +1,89 @@
+package com.rpeters.cinefintv.ui.screens.stuff
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.Button
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.rpeters.cinefintv.ui.components.TvMediaCard
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun StuffLibraryScreen(
+    onOpenItem: (String) -> Unit,
+    viewModel: StuffLibraryViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.load()
+    }
+
+    when (val state = uiState) {
+        is StuffLibraryUiState.Loading -> {
+            Text(
+                text = "Loading Stuff (Home Videos)...",
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.padding(48.dp),
+            )
+        }
+
+        is StuffLibraryUiState.Error -> {
+            androidx.compose.foundation.layout.Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(48.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text("Stuff could not load", style = MaterialTheme.typography.headlineLarge)
+                Text(
+                    text = state.message,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Button(onClick = { viewModel.load(forceRefresh = true) }) {
+                    Text("Retry")
+                }
+            }
+        }
+
+        is StuffLibraryUiState.Content -> {
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(4),
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = 48.dp, vertical = 32.dp),
+                horizontalArrangement = Arrangement.spacedBy(20.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+            ) {
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    Text(
+                        text = "Stuff (Home Videos)",
+                        style = MaterialTheme.typography.displaySmall,
+                    )
+                }
+                items(state.items, key = { it.id }) { item ->
+                    TvMediaCard(
+                        title = item.title,
+                        subtitle = item.subtitle,
+                        imageUrl = item.imageUrl,
+                        onClick = { onOpenItem(item.id) },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/rpeters/cinefintv/ui/screens/stuff/StuffLibraryViewModel.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/screens/stuff/StuffLibraryViewModel.kt
@@ -1,0 +1,63 @@
+package com.rpeters.cinefintv.ui.screens.stuff
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.rpeters.cinefintv.data.repository.JellyfinRepositoryCoordinator
+import com.rpeters.cinefintv.data.repository.common.ApiResult
+import com.rpeters.cinefintv.utils.getDisplayTitle
+import com.rpeters.cinefintv.utils.getFormattedDuration
+import com.rpeters.cinefintv.utils.getYear
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+sealed class StuffLibraryUiState {
+    data object Loading : StuffLibraryUiState()
+    data class Error(val message: String) : StuffLibraryUiState()
+    data class Content(val items: List<StuffItemCardModel>) : StuffLibraryUiState()
+}
+
+data class StuffItemCardModel(
+    val id: String,
+    val title: String,
+    val subtitle: String?,
+    val imageUrl: String?,
+)
+
+@HiltViewModel
+class StuffLibraryViewModel @Inject constructor(
+    private val repositories: JellyfinRepositoryCoordinator,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow<StuffLibraryUiState>(StuffLibraryUiState.Loading)
+    val uiState: StateFlow<StuffLibraryUiState> = _uiState.asStateFlow()
+
+    fun load(forceRefresh: Boolean = false) {
+        if (!forceRefresh && _uiState.value is StuffLibraryUiState.Content) return
+
+        viewModelScope.launch {
+            _uiState.value = StuffLibraryUiState.Loading
+            when (val result = repositories.media.getLibraryItems(collectionType = "homevideos", limit = 180)) {
+                is ApiResult.Success -> {
+                    val cards = result.data.map {
+                        StuffItemCardModel(
+                            id = it.id.toString(),
+                            title = it.getDisplayTitle(),
+                            subtitle = it.getYear()?.toString() ?: it.getFormattedDuration(),
+                            imageUrl = repositories.stream.getSeriesImageUrl(it),
+                        )
+                    }
+                    _uiState.value = if (cards.isEmpty()) {
+                        StuffLibraryUiState.Error("No home videos were found in Stuff.")
+                    } else {
+                        StuffLibraryUiState.Content(cards)
+                    }
+                }
+                is ApiResult.Error -> _uiState.value = StuffLibraryUiState.Error(result.message)
+                is ApiResult.Loading -> Unit
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated TV-optimized view for the "Stuff" collection that represents home videos rather than reusing the generic library UX.  
- Expose a focused detail screen for home videos with hero/backdrop, metadata, play action, and related content to improve discovery and playback on TV devices.  
- Route Stuff items to their own navigation path so Stuff-specific behaviors (e.g. loading `homevideos`) can be implemented without affecting other library flows.

### Description
- Added a new `ui.screens.stuff` package containing `StuffLibraryScreen.kt` and `StuffLibraryViewModel.kt` to render a 4-column TV Material grid using `TvMediaCard` and to load `collectionType = "homevideos"`.  
- Added `StuffDetailScreen.kt` and `StuffDetailViewModel.kt` to present item hero/backdrop, metadata, overview, Play/Back actions, and a "More Stuff" carousel that sources additional home videos.  
- Updated navigation by adding `STUFF_DETAIL` and `stuffDetail()` to `NavRoutes`, replaced the generic library route for Stuff with `StuffLibraryScreen` in `NavGraph`, and added a composable for the `stuff/detail/{itemId}` destination that navigates into the player or other Stuff detail pages.  
- Updated the top-level tab label in `CinefinTvApp.kt` to `"Stuff (Home Videos)"` for clearer intent.

### Testing
- Attempted to compile Kotlin sources with `./gradlew :app:compileDebugKotlin`; the build failed because the environment could not resolve plugin `org.gradle.toolchains.foojay-resolver-convention:1.0.0`.  
- No further automated tests were run due to the blocked build environment preventing successful compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e5bded948327b040d6d9f177d392)