### PR TITLE
Hide media card watch checkmark while card is focused

### DIFF
--- a/app/src/main/java/com/rpeters/cinefintv/ui/components/TvMediaCard.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/components/TvMediaCard.kt
@@ -136,7 +136,7 @@ fun TvMediaCard(
             }
 
             // Watch status overlay (top-right corner)
-            if (watchStatus != WatchStatus.NONE) {
+            if (watchStatus != WatchStatus.NONE && !isFocused) {
                 WatchStatusOverlay(
                     status = watchStatus,
                     modifier = Modifier.align(Alignment.TopEnd)


### PR DESCRIPTION
### Motivation
- Prevent the watch-status badge/checkmark from showing while the media card is focused/hovered so the overlay does not conflict with focused state or focused UI visuals.

### Description
- Change in `app/src/main/java/com/rpeters/cinefintv/ui/components/TvMediaCard.kt`: the `WatchStatusOverlay` is now shown only when `watchStatus != WatchStatus.NONE && !isFocused` so the badge is suppressed while the card has focus.

### Testing
- Ran `./gradlew :app:compileDebugKotlin`, which failed due to a missing Java toolchain download URL for JDK 21 so no further automated builds/tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08ac22d4c8327a1e96c546cb5490d)