### PR TITLE
Remove Quality selection UI and tidy repository retry TODOs

### DIFF
--- a/app/src/main/java/com/rpeters/cinefintv/data/repository/common/BaseJellyfinRepository.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/data/repository/common/BaseJellyfinRepository.kt
@@ -7,8 +7,6 @@ import com.rpeters.cinefintv.data.cache.JellyfinCache
 import com.rpeters.cinefintv.data.repository.JellyfinAuthRepository
 import com.rpeters.cinefintv.data.session.JellyfinSessionManager
 import com.rpeters.cinefintv.data.utils.RepositoryUtils
-// TODO Task 24: restore when UI layer is copied
-// import com.rpeters.cinefintv.ui.utils.RetryManager
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -200,8 +198,6 @@ open class BaseJellyfinRepository @Inject constructor(
      * Executes a block with automatic retry logic and error handling.
      * This provides smart retry behavior for all repository operations.
      * ✅ STRICTMODE FIX: All network operations run on IO dispatcher
-     *
-     * TODO Task 24: restore RetryManager.withRetry call when UI layer is copied
      */
     protected suspend fun <T> executeWithRetry(
         operationName: String,
@@ -245,8 +241,6 @@ open class BaseJellyfinRepository @Inject constructor(
      * Executes a block with both retry logic and circuit breaker protection.
      * Use this for critical operations that should be protected from cascading failures.
      * ✅ STRICTMODE FIX: All network operations run on IO dispatcher
-     *
-     * TODO Task 24: restore RetryManager.withRetryAndCircuitBreaker call when UI layer is copied
      */
     protected suspend fun <T> executeWithRetryAndCircuitBreaker(
         operationName: String,

--- a/app/src/main/java/com/rpeters/cinefintv/ui/player/PlayerControls.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/player/PlayerControls.kt
@@ -23,7 +23,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AudioFile
 import androidx.compose.material.icons.filled.Forward10
-import androidx.compose.material.icons.filled.HighQuality
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
@@ -75,7 +74,6 @@ internal fun PlayerControls(
     val defaultBounds = Rect.Zero
     val (subtitleButtonBounds, setSubtitleButtonBounds) = remember { mutableStateOf(defaultBounds) }
     val (audioButtonBounds, setAudioButtonBounds) = remember { mutableStateOf(defaultBounds) }
-    val (qualityButtonBounds, setQualityButtonBounds) = remember { mutableStateOf(defaultBounds) }
     val (speedButtonBounds, setSpeedButtonBounds) = remember { mutableStateOf(defaultBounds) }
     val (moreButtonBounds, setMoreButtonBounds) = remember { mutableStateOf(defaultBounds) }
 
@@ -313,22 +311,6 @@ internal fun PlayerControls(
                                 Icon(
                                     Icons.Default.AudioFile,
                                     contentDescription = "Audio",
-                                    modifier = Modifier.size(20.dp)
-                                )
-                            }
-
-                            OutlinedButton(
-                                onClick = {
-                                    onInteract()
-                                    onSettingsClick(SettingsSection.QUALITY, qualityButtonBounds)
-                                },
-                                modifier = Modifier.onGloballyPositioned { coordinates ->
-                                    setQualityButtonBounds(coordinates.boundsInRoot())
-                                },
-                            ) {
-                                Icon(
-                                    Icons.Default.HighQuality,
-                                    contentDescription = "Quality",
                                     modifier = Modifier.size(20.dp)
                                 )
                             }

--- a/app/src/main/java/com/rpeters/cinefintv/ui/player/PlayerTrackPanel.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/player/PlayerTrackPanel.kt
@@ -31,10 +31,9 @@ import androidx.tv.material3.SurfaceDefaults
 import androidx.tv.material3.Text
 import kotlin.math.roundToInt
 
-internal enum class SettingsSection { AUDIO, SUBTITLES, QUALITY, SPEED, ALL }
+internal enum class SettingsSection { AUDIO, SUBTITLES, SPEED, ALL }
 
 private val PLAYBACK_SPEEDS = listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 2.0f)
-private val QUALITY_OPTIONS = listOf("Auto", "1080p", "720p", "480p")
 private val PopupWidth = 420.dp
 private val PopupMaxHeight = 420.dp
 private val PopupVerticalGap = 16.dp
@@ -87,7 +86,6 @@ internal fun PlayerTrackPanel(
                 val panelTitle = when (section) {
                     SettingsSection.AUDIO -> "Audio"
                     SettingsSection.SUBTITLES -> "Subtitles"
-                    SettingsSection.QUALITY -> "Quality"
                     SettingsSection.SPEED -> "Playback Speed"
                     SettingsSection.ALL -> "Playback Options"
                 }
@@ -167,31 +165,6 @@ internal fun PlayerTrackPanel(
                                         onClose()
                                     },
                                 )
-                            }
-                        }
-
-                        if (section == SettingsSection.QUALITY || section == SettingsSection.ALL) {
-                            if (section == SettingsSection.ALL) {
-                                item {
-                                    Spacer(Modifier.height(4.dp))
-                                    Text(
-                                        text = "Quality",
-                                        style = MaterialTheme.typography.titleMedium,
-                                        color = MaterialTheme.colorScheme.primary,
-                                    )
-                                }
-                            }
-                            items(QUALITY_OPTIONS.size) { index ->
-                                val quality = QUALITY_OPTIONS[index]
-                                OutlinedButton(
-                                    onClick = {
-                                        onInteract()
-                                        onClose()
-                                    },
-                                    modifier = Modifier.fillMaxWidth(),
-                                ) {
-                                    Text(quality)
-                                }
                             }
                         }
 


### PR DESCRIPTION
### Motivation
- Remove the now-unused quality selection UI and related options from the player settings to match the current UI surface.
- Eliminate dangling references to a `RetryManager` helper in the repository layer while the UI layer remains separated.

### Description
- Removed the `HighQuality` icon import, `qualityButtonBounds` state, and the Quality `OutlinedButton` from `PlayerControls.kt`.
- Removed the `QUALITY` value from `SettingsSection`, removed `QUALITY_OPTIONS`, and removed the Quality section and title mapping from `PlayerTrackPanel.kt`.
- Commented out the `RetryManager` import and removed the `RetryManager`-related TODO lines in `BaseJellyfinRepository.kt` to avoid referencing a UI-layer retry helper.

### Testing
- Built the app with `./gradlew assembleDebug` which completed successfully.
- Ran unit tests with `./gradlew test` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08a979c50832785b6af3c0729db58)