### PR TITLE
fix: correct 1440p quality labeling in Stuff detail screen

### DIFF
--- a/app/src/main/java/com/rpeters/cinefintv/ui/screens/stuff/StuffDetailViewModel.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/screens/stuff/StuffDetailViewModel.kt
@@ -77,6 +77,7 @@ class StuffDetailViewModel @Inject constructor(
     private fun heightToResolutionLabel(height: Int?): String? = when {
         height == null -> null
         height >= 2160 -> "4K"
+        height >= 1440 -> "1440p"
         height >= 1080 -> "1080p"
         height >= 720 -> "720p"
         height >= 480 -> "480p"


### PR DESCRIPTION
### Motivation
- The Stuff detail screen was incorrectly classifying 1440p videos as `1080p`, so the visible technical details needed a dedicated 1440p tier.

### Description
- Added a `height >= 1440 -> "1440p"` branch to `heightToResolutionLabel` in `app/src/main/java/com/rpeters/cinefintv/ui/screens/stuff/StuffDetailViewModel.kt` to correctly map 1440p sources.

### Testing
- Attempted to compile with `./gradlew :app:compileDebugKotlin`, but the build could not run in this environment due to Gradle toolchain auto-provisioning for Java 21 not being configured (`No defined toolchain download url`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b09605f47c8327a4a7bf0d8d791f44)