### PR TITLE
Add technical stream details and subtitle picker to Detail screen

### DIFF
--- a/app/src/main/java/com/rpeters/cinefintv/ui/screens/detail/DetailScreen.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/screens/detail/DetailScreen.kt
@@ -28,6 +28,11 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.ClosedCaption
+import androidx.compose.material.icons.filled.GraphicEq
+import androidx.compose.material.icons.filled.HighQuality
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.Speaker
 import androidx.compose.runtime.Composable
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.LaunchedEffect
@@ -127,6 +132,10 @@ fun DetailScreen(
                 val item = state.item
                 val episodes = state.episodesBySeasonId.values.flatten()
                 val isSeriesDetail = state.seasons.isNotEmpty()
+                var subtitlesExpanded by remember { mutableStateOf(false) }
+                var selectedSubtitle by remember(item.subtitleOptions) {
+                    mutableStateOf(item.subtitleOptions.firstOrNull())
+                }
 
                 LaunchedEffect(state.isDeleted) {
                     if (state.isDeleted) {
@@ -302,6 +311,126 @@ fun DetailScreen(
                                                             maxLines = 1,
                                                             overflow = TextOverflow.Ellipsis,
                                                         )
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                item.technicalDetails?.let { details ->
+                                    val technicalRows = listOfNotNull(
+                                        details.videoQuality?.let {
+                                            DetailInfoRowModel("Video Quality", it, Icons.Default.HighQuality)
+                                        },
+                                        details.audioCodec?.let {
+                                            DetailInfoRowModel("Audio Codec", it, Icons.Default.GraphicEq)
+                                        },
+                                        details.audioType?.let {
+                                            DetailInfoRowModel("Audio Type", it, Icons.Default.Speaker)
+                                        },
+                                        details.language?.let {
+                                            DetailInfoRowModel("Language", it, Icons.Default.Language)
+                                        },
+                                    )
+
+                                    if (technicalRows.isNotEmpty()) {
+                                        FlowRow(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                                        ) {
+                                            technicalRows.forEach { infoRow ->
+                                                Surface(
+                                                    shape = RoundedCornerShape(12.dp),
+                                                    colors = SurfaceDefaults.colors(
+                                                        containerColor = Color.Black.copy(alpha = 0.4f)
+                                                    ),
+                                                    modifier = Modifier.border(
+                                                        width = 1.dp,
+                                                        color = MaterialTheme.colorScheme.border.copy(alpha = 0.3f),
+                                                        shape = RoundedCornerShape(12.dp)
+                                                    )
+                                                ) {
+                                                    Row(
+                                                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+                                                        verticalAlignment = Alignment.CenterVertically,
+                                                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                                                    ) {
+                                                        infoRow.icon?.let {
+                                                            Icon(
+                                                                imageVector = it,
+                                                                contentDescription = null,
+                                                                modifier = Modifier.size(20.dp),
+                                                                tint = MaterialTheme.colorScheme.primary
+                                                            )
+                                                        }
+                                                        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                                            Text(
+                                                                text = infoRow.label.uppercase(),
+                                                                style = MaterialTheme.typography.labelSmall,
+                                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                                fontWeight = FontWeight.Bold
+                                                            )
+                                                            Text(
+                                                                text = infoRow.value,
+                                                                style = MaterialTheme.typography.titleSmall,
+                                                                color = MaterialTheme.colorScheme.onBackground,
+                                                            )
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                if (item.subtitleOptions.isNotEmpty()) {
+                                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        Text(
+                                            text = "Subtitles",
+                                            style = MaterialTheme.typography.titleMedium,
+                                            color = MaterialTheme.colorScheme.onBackground,
+                                            fontWeight = FontWeight.SemiBold,
+                                        )
+                                        Button(
+                                            onClick = { subtitlesExpanded = !subtitlesExpanded },
+                                            modifier = Modifier.onFocusChanged { if (it.isFocused) focusedDescription = null }
+                                        ) {
+                                            Icon(Icons.Default.ClosedCaption, contentDescription = null)
+                                            Spacer(Modifier.width(8.dp))
+                                            Text(selectedSubtitle ?: "Choose subtitle")
+                                        }
+
+                                        if (subtitlesExpanded) {
+                                            Surface(
+                                                shape = RoundedCornerShape(12.dp),
+                                                colors = SurfaceDefaults.colors(
+                                                    containerColor = Color.Black.copy(alpha = 0.7f)
+                                                ),
+                                                modifier = Modifier.fillMaxWidth(0.45f)
+                                            ) {
+                                                Column(
+                                                    modifier = Modifier.padding(12.dp),
+                                                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                                                ) {
+                                                    item.subtitleOptions.forEach { option ->
+                                                        val isSelected = selectedSubtitle == option
+                                                        if (isSelected) {
+                                                            Button(onClick = {
+                                                                selectedSubtitle = option
+                                                                subtitlesExpanded = false
+                                                            }) {
+                                                                Text(option)
+                                                            }
+                                                        } else {
+                                                            OutlinedButton(onClick = {
+                                                                selectedSubtitle = option
+                                                                subtitlesExpanded = false
+                                                            }) {
+                                                                Text(option)
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }

--- a/app/src/main/java/com/rpeters/cinefintv/ui/screens/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/ui/screens/detail/DetailViewModel.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.MediaStreamType
 
 data class DetailInfoRowModel(
     val label: String,
@@ -59,7 +60,16 @@ data class DetailHeroModel(
     val backdropUrl: String?,
     val metaBadges: List<String>,
     val infoRows: List<DetailInfoRowModel>,
+    val technicalDetails: DetailTechnicalDetails? = null,
+    val subtitleOptions: List<String> = emptyList(),
     val cast: List<DetailPersonModel> = emptyList(),
+)
+
+data class DetailTechnicalDetails(
+    val videoQuality: String?,
+    val audioCodec: String?,
+    val audioType: String?,
+    val language: String?,
 )
 
 data class DetailSeasonModel(
@@ -104,6 +114,24 @@ class DetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val repositories: JellyfinRepositoryCoordinator,
 ) : ViewModel() {
+    private fun Int?.toVideoQualityLabel(): String? = when {
+        this == null -> null
+        this >= 2160 -> "4K"
+        this >= 1440 -> "1440p"
+        this >= 1080 -> "1080p"
+        this >= 720 -> "720p"
+        this >= 480 -> "480p"
+        else -> "${this}p"
+    }
+
+    private fun Int?.toAudioTypeLabel(): String? = when {
+        this == null || this <= 0 -> null
+        this >= 8 -> "7.1"
+        this >= 6 -> "5.1"
+        this >= 2 -> "Stereo"
+        else -> "Mono"
+    }
+
     private val itemId: String = savedStateHandle.get<String>("itemId").orEmpty()
     private val _uiState = MutableStateFlow<DetailUiState>(DetailUiState.Loading)
     val uiState: StateFlow<DetailUiState> = _uiState.asStateFlow()
@@ -358,6 +386,29 @@ class DetailViewModel @Inject constructor(
             )
         }
 
+        val streams = item.mediaSources?.firstOrNull()?.mediaStreams ?: item.mediaStreams.orEmpty()
+        val videoStream = streams.firstOrNull { it.type == MediaStreamType.VIDEO }
+        val audioStream = streams.firstOrNull { it.type == MediaStreamType.AUDIO }
+        val subtitleOptions = streams
+            .filter { it.type == MediaStreamType.SUBTITLE }
+            .mapNotNull {
+                it.displayTitle
+                    ?: it.displayLanguage
+                    ?: it.language
+                    ?: it.title
+            }
+            .filter { it.isNotBlank() }
+            .distinct()
+
+        val technicalDetails = DetailTechnicalDetails(
+            videoQuality = videoStream?.height.toVideoQualityLabel(),
+            audioCodec = videoStream?.audioCodec?.takeIf { it.isNotBlank() }
+                ?: audioStream?.codec?.takeIf { it.isNotBlank() }?.uppercase(),
+            audioType = audioStream?.channels.toAudioTypeLabel(),
+            language = audioStream?.displayLanguage?.takeIf { it.isNotBlank() }
+                ?: audioStream?.language?.takeIf { it.isNotBlank() },
+        )
+
         return DetailHeroModel(
             id = item.id.toString(),
             title = item.getDisplayTitle(),
@@ -367,6 +418,8 @@ class DetailViewModel @Inject constructor(
             backdropUrl = repositories.stream.getBackdropUrlWithFallback(item, parentForBackdrop),
             metaBadges = metaBadges,
             infoRows = infoRows,
+            technicalDetails = technicalDetails,
+            subtitleOptions = subtitleOptions,
             cast = cast,
         )
     }


### PR DESCRIPTION
### Motivation
- Surface richer media metadata on the Detail screen so users can see video quality, audio codec/type, and language, and pick subtitle tracks directly from the UI.

### Description
- Extend the detail model with `DetailTechnicalDetails` and `subtitleOptions` on `DetailHeroModel` and add helpers `toVideoQualityLabel` and `toAudioTypeLabel` to derive friendly labels from stream properties.
- Parse media streams in `DetailViewModel` to extract video height, audio codec/channels/language and subtitle track display names and populate the new model fields.
- Render technical info as info chips on the Detail UI with Material icons (`HighQuality`, `GraphicEq`, `Speaker`, `Language`) and add a subtitle dropdown UI that lets users open a list and select a subtitle option.
- Modified files: `app/src/main/java/com/rpeters/cinefintv/ui/screens/detail/DetailViewModel.kt` and `app/src/main/java/com/rpeters/cinefintv/ui/screens/detail/DetailScreen.kt`.

### Testing
- Attempted to run unit tests with `./gradlew :app:testDebugUnitTest --no-daemon`, which failed in this environment because Gradle could not provision JDK toolchain 21 due to no toolchain download URL being configured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b09fcd3768832794fa8076d7cbf1e3)