### PR TITLE
Add round launcher icon wiring and branding asset dimension validation

### DIFF
--- a/app/assets/branding/README.md
+++ b/app/assets/branding/README.md
@@ -1,0 +1,9 @@
+# Branding source assets
+
+Place the high-resolution branding files in this folder before release:
+
+- `launcher-icon.png` — expected size: **1024x1024**
+- `launcher-icon-round.png` — expected size: **1024x1024**
+- `tv-banner.png` — expected size: **1536x864**
+
+Use `python tools/validate_icon_dimensions.py` to verify pixel dimensions.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:name=".CinefinTvApplication"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:banner="@drawable/tv_banner"
         android:label="@string/app_name"
         android:theme="@style/Theme.CinefinTV"

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background"/>
+    <foreground android:drawable="@color/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background"/>
+    <foreground android:drawable="@color/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-hdpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-hdpi/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background"/>
+    <foreground android:drawable="@color/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/tools/validate_icon_dimensions.py
+++ b/tools/validate_icon_dimensions.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import struct
+
+EXPECTED = {
+    "launcher-icon.png": (1024, 1024),
+    "launcher-icon-round.png": (1024, 1024),
+    "tv-banner.png": (1536, 864),
+}
+
+
+def read_png_size(path: Path) -> tuple[int, int]:
+    with path.open("rb") as f:
+        signature = f.read(8)
+        if signature != b"\x89PNG\r\n\x1a\n":
+            raise ValueError("not a PNG file")
+
+        length = struct.unpack(">I", f.read(4))[0]
+        chunk_type = f.read(4)
+        if chunk_type != b"IHDR" or length != 13:
+            raise ValueError("invalid PNG IHDR chunk")
+
+        width, height = struct.unpack(">II", f.read(8))
+        return width, height
+
+
+base = Path("app/assets/branding")
+failed = False
+
+for name, expected in EXPECTED.items():
+    path = base / name
+    if not path.exists():
+        print(f"MISSING: {path}")
+        failed = True
+        continue
+
+    try:
+        actual = read_png_size(path)
+    except Exception as exc:
+        print(f"INVALID: {path} ({exc})")
+        failed = True
+        continue
+
+    if actual != expected:
+        print(f"INVALID: {path} is {actual[0]}x{actual[1]} (expected {expected[0]}x{expected[1]})")
+        failed = True
+    else:
+        print(f"OK: {path} is {actual[0]}x{actual[1]}")
+
+raise SystemExit(1 if failed else 0)


### PR DESCRIPTION
### Motivation
- Provide explicit round-icon support for launchers that prefer circular icons (Android TV/Leanback and other devices). 
- Ensure release branding art is the correct pixel dimensions before it is integrated into the app. 
- Add a simple, dependency-free validation tool so CI or maintainers can quickly verify supplied PNGs.

### Description
- Add `android:roundIcon="@mipmap/ic_launcher_round"` to the application element in `app/src/main/AndroidManifest.xml` to wire round icon support. 
- Add `ic_launcher_round.xml` adaptive-icon resources in `app/src/main/res/mipmap-anydpi-v26/`, `app/src/main/res/mipmap-anydpi/`, and `app/src/main/res/mipmap-hdpi/`. 
- Add `app/assets/branding/README.md` documenting the expected source sizes: `launcher-icon.png` 1024x1024, `launcher-icon-round.png` 1024x1024, and `tv-banner.png` 1536x864. 
- Add `tools/validate_icon_dimensions.py`, a small PNG IHDR-based checker (no external deps) and mark it executable to validate the three branding PNGs.

### Testing
- Attempted to run `python tools/validate_icon_dimensions.py` with a PIL-based implementation which failed due to missing `PIL` (reported `ModuleNotFoundError`), so a dependency-free reader was implemented. 
- Ran the final `python tools/validate_icon_dimensions.py` which correctly inspects PNG IHDR sizes and reported `MISSING` for `app/assets/branding/launcher-icon.png`, `launcher-icon-round.png`, and `tv-banner.png`, and exited non-zero as expected until the real assets are added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2fea91f308327b5aa966f133baa11)