### PR TITLE
docs: refresh README project status and polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CinefinTV
 
-CinefinTV is a **native Android TV client for Jellyfin**, built with modern Android tooling (Kotlin, Jetpack Compose for TV, Media3, Hilt, Retrofit/OkHttp).
+CinefinTV is a **native Android TV client for Jellyfin** built with modern Android tooling: Kotlin, Jetpack Compose for TV, Media3, Hilt, Retrofit, and OkHttp.
 
-It targets a 10-foot experience (D-pad navigation, focused controls, large UI primitives) and currently delivers an MVP end-to-end flow: connect to a Jellyfin server, sign in, browse media, and play content.
+It is designed for a true 10-foot TV experience with D-pad-first navigation, focus-aware UI, and playback controls that feel native on remote devices.
 
 ---
 
@@ -12,62 +12,82 @@ It targets a 10-foot experience (D-pad navigation, focused controls, large UI pr
 
 **[⬇ Download latest signed APK](https://github.com/rpeters1430/CinefinTV/releases/latest/download/app-release.apk)**
 
-The APK is signed and published automatically whenever a new version is released via `./publish.sh` on Unix-like shells or `.\publish.ps1` on Windows PowerShell. Each release also pushes an updated `updates/version.json` so the in-app updater can notify existing users.
+Releases are published through `./publish.sh` (Unix-like shells) or `./publish.ps1` (PowerShell). The release process also updates `updates/version.json`, which is used by the in-app updater.
 
-You can also browse all releases on the [Releases page](https://github.com/rpeters1430/CinefinTV/releases).
+You can browse all published versions on the [Releases page](https://github.com/rpeters1430/CinefinTV/releases).
 
 ### Installation
-1. On your Android TV device, enable **Unknown sources** (Settings → Device Preferences → Security & Restrictions).
-2. Download the APK to your device (via a browser, USB, or `adb sideload`).
-3. Open the APK file to install.
+
+1. On your Android TV device, enable **Unknown sources**.
+2. Download the APK (browser, USB, or `adb`).
+3. Open the APK file and complete installation.
 
 ---
 
-## Project status (current)
+## Project status
 
-**Status:** MVP feature-complete and running on real Android TV hardware.
+**Last updated:** **April 3, 2026**  
+**Current app version:** **1.6.4 (versionCode 65)**  
+**Lifecycle stage:** **Beta**
 
-What is currently working:
-- Full authentication flow (server URL + user login)
-- Saved session restore on cold start
-- Home feed with server-backed rows (continue watching + recently added)
-- Library browsing (movies / TV / home videos)
-- Search with debounced query and grid results
-- Music browsing (albums/artists, album tracks)
-- Video playback with custom TV controls overlay
+CinefinTV is past MVP and currently supports the full end-to-end user journey:
 
-See `docs/plans/2026-03-02-cinefintv-status.md` for a detailed status snapshot and known issues.
-See `docs/plans/2026-03-09-app-upgrade-roadmap.md` for the prioritized upgrade plan.
+- Server connection and authentication (including Quick Connect and session restore)
+- Home feed with watch-state aware sections
+- Library browsing with filtering/sorting
+- Search across multiple content types
+- Rich detail pages for movies, shows, seasons, people, and collections
+- Video playback with resume, track selection, and quality controls
+- Audio playback with MediaSession-backed queue behavior
+- Settings persistence via DataStore
+
+### Current focus areas
+
+The project is stable and usable, with active work centered on:
+
+- Reliability hardening (cache, network, and concurrency edge cases)
+- Dependency stabilization (reducing alpha/pre-release usage)
+- Navigation/focus refinements across TV surfaces
+- Playback and update-flow quality improvements
+- Expanded automated coverage for critical runtime behavior
+
+For full implementation details and known issues, see:
+
+- `docs/2026-04-03-project-status-report.md`
+- `docs/plans/2026-03-09-app-upgrade-roadmap.md`
 
 ---
 
-## Features
+## Feature overview
 
-### Auth
-- Server connection screen with URL validation/testing
+### Authentication
+
+- Server connection with validation/testing
 - Username/password login
-- Session persistence and restore
+- Quick Connect polling flow
+- Session persistence and secure restore
 
-### Browsing
-- Home sections:
-  - Continue Watching
-  - Recently Added Movies
-  - Recently Added TV
-  - Recently Added Videos
-  - Libraries
-- Library categories via shared library screen
-- Search with lazy grid UI
-- Music mode (Albums/Artists + album detail track listing)
+### Browsing and discovery
+
+- Home sections (continue watching, recently added, libraries)
+- Dedicated library browsing for movies, TV, and collections
+- Debounced search with grid results
+- Music browsing (albums/artists and album detail track lists)
+- Detail screens with cast/similar metadata
 
 ### Playback
+
 - Media3-powered fullscreen player
-- Custom TV overlay controls:
-  - Back
-  - Play/Pause
-  - Seek ±10 seconds
-  - Progress + timestamps
-- Auto-hide controls and periodic playback state polling
-- OkHttp-backed data source so authenticated streams work consistently
+- Custom TV control overlay
+- Seek, progress, and timestamp controls
+- Resume, chapter-aware skip actions, and next-item flows
+- Audio/subtitle track selection and quality switching
+
+### Settings and security
+
+- Persisted playback/subtitle/appearance preferences
+- Android Keystore-backed encryption
+- Sensitive logging/header redaction safeguards
 
 ---
 
@@ -75,10 +95,10 @@ See `docs/plans/2026-03-09-app-upgrade-roadmap.md` for the prioritized upgrade p
 
 - **Language:** Kotlin
 - **UI:** Jetpack Compose + Compose for TV Material
-- **Dependency Injection:** Hilt (KSP)
+- **DI:** Hilt (KSP)
 - **Playback:** AndroidX Media3 + Jellyfin FFmpeg integration
 - **Networking:** Retrofit + OkHttp
-- **Persistence:** DataStore Preferences + Android Keystore–backed encryption
+- **Persistence:** DataStore Preferences + Android Keystore-backed encryption
 - **Architecture:** MVVM-style ViewModels with repository coordination
 
 ---
@@ -86,10 +106,10 @@ See `docs/plans/2026-03-09-app-upgrade-roadmap.md` for the prioritized upgrade p
 ## Requirements
 
 - Android Studio (latest stable recommended)
-- Android SDK installed (project compiles with `compileSdk 36`)
+- Android SDK (`compileSdk 36`)
 - JDK 21
-- A reachable Jellyfin server account for end-to-end usage
-- Linux users can bootstrap dependencies with `./setup_linux.sh` on Ubuntu, Debian, Fedora, CachyOS, and Arch Linux
+- A reachable Jellyfin server account
+- Linux users can bootstrap dependencies with `./setup_linux.sh`
 
 ---
 
@@ -105,30 +125,41 @@ adb install app/build/outputs/apk/debug/app-debug.apk
 
 ---
 
+## Development commands
+
+From the repository root:
+
+```bash
+./gradlew :app:assembleDebug
+./gradlew :app:testDebugUnitTest
+./gradlew :app:connectedDebugAndroidTest
+./gradlew :app:lintDebug
+```
+
+To publish a release and refresh update metadata:
+
+```bash
+./publish.sh
+```
+
+---
+
 ## Testing
 
-Run unit tests:
+Run JVM unit tests:
 
 ```bash
 ./gradlew :app:testDebugUnitTest
 ```
 
-Current tests are focused on ViewModels and supporting test utilities.
+Run Android TV instrumented tests (device/emulator required):
 
----
-
-## Known gaps / next priorities
-
-- Execute a full TV QA regression sweep (emulator + real device) and prioritize defects
-- Fix focus/navigation consistency issues across home rows, tabs, and detail actions
-- Harden playback edge cases (stream errors, saved position recovery, autoplay boundaries)
-- Improve visual polish (contrast/readability, spacing, metadata density)
-- Expand tests for playback transitions and focus-critical UI behavior
-
-For full sequencing and success metrics, follow `docs/plans/2026-03-09-app-upgrade-roadmap.md`.
+```bash
+./gradlew :app:connectedDebugAndroidTest
+```
 
 ---
 
 ## License
 
-This project is licensed under the terms of the [MIT License](LICENSE).
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
### Motivation
- Update and polish the repository `README.md` to present an accurate, date-stamped project status and improve first-time-reader onboarding.
- Clarify feature coverage, developer workflow, and testing instructions so contributors can find relevant docs and the project status quickly.

### Description
- Rewrote the README intro to better describe the 10-foot Android TV focus and tech stack and simplified the download/install instructions.
- Replaced the old “MVP current status” with a date-stamped status snapshot (`April 3, 2026`), version metadata, and a concise list of current focus areas and capabilities.
- Reorganized feature documentation into clearer sections (Authentication, Browsing/Discovery, Playback, Settings/Security) and compacted the tech stack and requirements.
- Improved developer guidance by separating `Getting started`, `Development commands`, and `Testing` sections and pointing to `docs/2026-04-03-project-status-report.md` for detailed status and roadmap.

### Testing
- Ran unit test task `./gradlew :app:testDebugUnitTest` which failed in this environment due to Gradle toolchain provisioning being unable to download JDK 21 with the error: `No defined toolchain download url for LINUX on x86_64 architecture`.
- No repository build or instrumented tests were completed in this environment because the local Gradle toolchain provisioning issue blocks JVM test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d825bf95d88327bcc37343490ee609)