### PR TITLE
Default HTTP for IP addresses and localhost in server URL validation

### DIFF
--- a/app/src/main/java/com/rpeters/cinefintv/utils/ServerUrlValidator.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/utils/ServerUrlValidator.kt
@@ -37,8 +37,17 @@ object ServerUrlValidator {
 
         // Add protocol if missing
         if (!url.startsWith("http://") && !url.startsWith("https://")) {
-            // Default to HTTPS for modern Jellyfin setups
-            url = "https://$url"
+            // Only assume SSL when the user explicitly typed a scheme. A bare
+            // IP address (or "localhost") is typically a direct, unencrypted
+            // LAN connection, so default those to HTTP. Hostnames/domains are
+            // more likely to sit behind a reverse proxy with TLS, so keep
+            // defaulting those to HTTPS.
+            val hostPart = url.substringBefore("/").substringBefore(":")
+            url = if (isValidIPAddress(hostPart) || hostPart.equals("localhost", ignoreCase = true)) {
+                "http://$url"
+            } else {
+                "https://$url"
+            }
         }
 
         // Validate the final URL

--- a/app/src/main/java/com/rpeters/cinefintv/utils/ServerUrlValidator.kt
+++ b/app/src/main/java/com/rpeters/cinefintv/utils/ServerUrlValidator.kt
@@ -42,12 +42,16 @@ object ServerUrlValidator {
             // LAN connection, so default those to HTTP. Hostnames/domains are
             // more likely to sit behind a reverse proxy with TLS, so keep
             // defaulting those to HTTPS.
-            val hostPart = url.substringBefore("/").substringBefore(":")
-            url = if (isValidIPAddress(hostPart) || hostPart.equals("localhost", ignoreCase = true)) {
-                "http://$url"
+            val hostPart = extractHostForSchemeInference(url)
+            val isIpHost = isValidIPAddress(hostPart) || hostPart.equals("localhost", ignoreCase = true)
+            // A bare (unbracketed) IPv6 literal must be wrapped in brackets to
+            // form a valid URI authority, e.g. "::1" -> "[::1]".
+            val authority = if (!url.startsWith("[") && hostPart.count { it == ':' } > 1) {
+                url.replaceFirst(hostPart, "[$hostPart]")
             } else {
-                "https://$url"
+                url
             }
+            url = if (isIpHost) "http://$authority" else "https://$authority"
         }
 
         // Validate the final URL
@@ -290,6 +294,20 @@ object ServerUrlValidator {
         } catch (e: MalformedURLException) {
             SecureLogger.w(TAG, "Malformed URL: $url", e)
             false
+        }
+    }
+
+    /**
+     * Extracts the host portion of a scheme-less input for classifying it as an
+     * IP address vs. a hostname. Handles bracketed IPv6 literals (`[::1]:8096`)
+     * and bare IPv6 literals (`2001:db8::1`), which contain colons that would
+     * otherwise be mistaken for a port separator.
+     */
+    private fun extractHostForSchemeInference(url: String): String {
+        return when {
+            url.startsWith("[") -> url.substringAfter("[").substringBefore("]")
+            url.count { it == ':' } > 1 -> url.substringBefore("/")
+            else -> url.substringBefore("/").substringBefore(":")
         }
     }
 

--- a/app/src/test/java/com/rpeters/cinefintv/utils/ServerUrlValidatorTest.kt
+++ b/app/src/test/java/com/rpeters/cinefintv/utils/ServerUrlValidatorTest.kt
@@ -67,6 +67,27 @@ class ServerUrlValidatorTest {
     }
 
     @Test
+    fun validateAndNormalizeUrl_forBracketedIpv6WithPortWithoutScheme_defaultsToHttp() {
+        val normalized = ServerUrlValidator.validateAndNormalizeUrl("[::1]:8096")
+
+        assertEquals("http://[::1]:8096", normalized)
+    }
+
+    @Test
+    fun validateAndNormalizeUrl_forBracketedIpv6WithoutPortOrScheme_defaultsToHttp() {
+        val normalized = ServerUrlValidator.validateAndNormalizeUrl("[::1]")
+
+        assertEquals("http://[::1]", normalized)
+    }
+
+    @Test
+    fun validateAndNormalizeUrl_forBareIpv6WithoutScheme_defaultsToHttpAndAddsBrackets() {
+        val normalized = ServerUrlValidator.validateAndNormalizeUrl("::1")
+
+        assertEquals("http://[::1]", normalized)
+    }
+
+    @Test
     fun normalizeServerUrl_stripsDefaultHttpsPort() {
         val result1 = normalizeServerUrl("https://jellyfin.example.com")
         val result2 = normalizeServerUrl("https://jellyfin.example.com:443")

--- a/app/src/test/java/com/rpeters/cinefintv/utils/ServerUrlValidatorTest.kt
+++ b/app/src/test/java/com/rpeters/cinefintv/utils/ServerUrlValidatorTest.kt
@@ -32,6 +32,41 @@ class ServerUrlValidatorTest {
     }
 
     @Test
+    fun validateAndNormalizeUrl_forIpAddressWithPortWithoutScheme_defaultsToHttp() {
+        val normalized = ServerUrlValidator.validateAndNormalizeUrl("10.1.1.20:8096")
+
+        assertEquals("http://10.1.1.20:8096", normalized)
+    }
+
+    @Test
+    fun validateAndNormalizeUrl_forIpAddressWithoutScheme_defaultsToHttp() {
+        val normalized = ServerUrlValidator.validateAndNormalizeUrl("192.168.1.50")
+
+        assertEquals("http://192.168.1.50", normalized)
+    }
+
+    @Test
+    fun validateAndNormalizeUrl_forIpAddressWithExplicitHttps_preservesHttps() {
+        val normalized = ServerUrlValidator.validateAndNormalizeUrl("https://10.1.1.20:8920")
+
+        assertEquals("https://10.1.1.20:8920", normalized)
+    }
+
+    @Test
+    fun validateAndNormalizeUrl_forLocalhostWithoutScheme_defaultsToHttp() {
+        val normalized = ServerUrlValidator.validateAndNormalizeUrl("localhost:8096")
+
+        assertEquals("http://localhost:8096", normalized)
+    }
+
+    @Test
+    fun validateAndNormalizeUrl_forDomainWithoutScheme_stillDefaultsToHttps() {
+        val normalized = ServerUrlValidator.validateAndNormalizeUrl("media.example.com")
+
+        assertEquals("https://media.example.com", normalized)
+    }
+
+    @Test
     fun normalizeServerUrl_stripsDefaultHttpsPort() {
         val result1 = normalizeServerUrl("https://jellyfin.example.com")
         val result2 = normalizeServerUrl("https://jellyfin.example.com:443")


### PR DESCRIPTION
## Summary
Updated `ServerUrlValidator` to intelligently default to HTTP for IP addresses and localhost, while preserving HTTPS as the default for domain names. This reflects real-world usage patterns where direct LAN connections typically use unencrypted HTTP, while domain-based connections often sit behind reverse proxies with TLS.

## Changes
- **Modified `validateAndNormalizeUrl()` logic**: Instead of always defaulting to HTTPS when no scheme is provided, the validator now:
  - Detects if the host is an IP address (IPv4/IPv6) or "localhost"
  - Defaults those to `http://`
  - Defaults all other hostnames/domains to `https://` (preserving existing behavior)
  
- **Added helper method**: Leverages existing `isValidIPAddress()` utility to classify the host

- **Added comprehensive test coverage**:
  - IP address with port, no scheme → defaults to HTTP
  - IP address without port, no scheme → defaults to HTTP
  - IP address with explicit HTTPS → preserves HTTPS
  - Localhost with port, no scheme → defaults to HTTP
  - Domain name without scheme → still defaults to HTTPS

## Implementation Details
The logic extracts the host portion (before any `/` or `:`) and checks if it's a valid IP or the literal string "localhost" (case-insensitive). This approach is simple, efficient, and handles both IPv4 and IPv6 addresses via the existing `isValidIPAddress()` function.

https://claude.ai/code/session_01VscNRpVEbZzCXueB94vCkq